### PR TITLE
Invoke the bonjour service in an asynchronous non-blocking fashion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
 			<version>${netflix.feign.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>io.reactivex</groupId>
+			<artifactId>rxjava</artifactId>
+			<version>1.1.2</version>
+		</dependency>
+
 		<!-- Vertx Hystrix Stream -->
 		<dependency>
 			<groupId>com.github.kennedyoliveira</groupId>

--- a/src/main/java/com/redhat/developers/msa/aloha/BonjourService.java
+++ b/src/main/java/com/redhat/developers/msa/aloha/BonjourService.java
@@ -17,10 +17,16 @@
 package com.redhat.developers.msa.aloha;
 
 import feign.RequestLine;
+import rx.Observable;
 
 public interface BonjourService {
 
-	@RequestLine("GET /api/bonjour")
-	public String bonjour();
+
+  /**
+   * To be invoked asynchronously and in a non-blocking fashion, we have to use an Observable here (because of Hystrix)
+   * @return an observable to get the response
+   */
+  @RequestLine("GET /api/bonjour")
+  Observable<String> bonjour();
 
 }


### PR DESCRIPTION
This way is compliant with Vert.x.

Notice that I had to change the service interface to use an `Observable` as it's the only way to be async and non-blocking.

Another approach (that does not require the service change) would be to use:

```
vertx.<List<String>>executeBlocking(
  future -> {
     // Blocking, but running on a worker thread
     future.complete(getTheResultingList());
  },
  ar -> {
   // Back on the event loop, can write in the response
  }
```

Both approaches have pros and cons.
