### PR TITLE
Add fabric8io/docker-maven-plugin for creating the docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,10 @@ Access the application
 
 The application will be running at the following URL: <http://localhost:8080/api/aloha>
 
+Create a Docker image with Maven
+--------------------------------
 
+1. Be sure that a Docker daemon is accessible via the `DOCKER_HOST` variable.
+1. Type this command to create a Docker image `redhatmsa/aloha`:
+
+        mvn package docker:build

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,42 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>0.14.2</version>
+				<configuration>
+					<images>
+						<image>
+							<name>redhatmsa/aloha</name>
+							<build>
+								<from>jboss/base-jdk:8</from>
+								<assembly>
+									<inline>
+										<files>
+											<file>
+												<source>${project.build.directory}/${project.artifactId}-${project.version}-fat.jar</source>
+												<destName>aloha.jar</destName>
+											</file>
+										</files>
+									</inline>
+								</assembly>
+								<cmd><shell>java -jar /maven/aloha.jar</shell></cmd>
+							</build>
+							<!-- Optional <run> section, can be omitted.
+							     Call 'mvn docker:start' to start and 'docker ps' to get the dynamic port.
+							     'mvn docker:stop' to stop ip, '-Ddocker.follow' to let start run in the foreground -->
+							<run>
+								<ports>
+									<!-- Property ${aloha.port} will be set with dynamic port,
+									     could be used in integration tests-->
+									<port>${aloha.port}:8080</port>
+								</ports>
+							</run>
+						</image>
+					</images>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
The Docker build configuration creates the same Docker image as declared in Dockerfile. In addition it already adds the proper name for the image (not possible to specify in the Dockerfile) + it would be able to push it to a registry.
Also it automatically updates to version upgrades, where a plain Dockerfile needs to be updared manually (there is an error btw in the current Dockerfile, it refers to the non-fat jar file in its ADD).

A sample run configuration is added which maps 8080 to a dynamic port and then assigns it to a Maven property ${aloha.port} which could be used in integration tests (along with ${docker.host.address} which is set to the IP of the Docker daemon).
The <run> section is optional and can be removed if not needed.
