### PR TITLE
Fix ERROR: No aloha-fat.jar found in /deployments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 							<build>
 								<from>${docker.from}</from>
 								<assembly>
-									<basedir>/app</basedir>
+									<basedir>/deployments</basedir>
 									<inline>
 										<id>${project.artifactId}</id>
 										<files>


### PR DESCRIPTION
When using `mvn clean package docker:build …`.