### PR TITLE
Fix warnings about type safety

### DIFF
--- a/src/main/java/com/redhat/developers/msa/aloha/TracingConfiguration.java
+++ b/src/main/java/com/redhat/developers/msa/aloha/TracingConfiguration.java
@@ -87,7 +87,7 @@ public class TracingConfiguration {
             Tags.ERROR.set(span, Boolean.TRUE);
 
             if (routingContext.failure() != null) {
-                Map<String, Object> errorLogs = new HashMap(2);
+                Map<String, Object> errorLogs = new HashMap<>(2);
                 errorLogs.put("event", Tags.ERROR.getKey());
                 errorLogs.put("error.object", routingContext.failure());
                 span.log(errorLogs);


### PR DESCRIPTION
Fix these warnings:

<img width="980" alt="screen shot 2017-05-25 at 9 18 37 am" src="https://cloud.githubusercontent.com/assets/148698/26451784/72044d5a-412b-11e7-9051-fcb2333e69b6.png">
