### PR TITLE
removing vertx.unit runtime dependence to scape exec error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
 			<groupId>com.github.kennedyoliveira</groupId>
 			<artifactId>hystrix-vertx-metrics-stream</artifactId>
 			<version>${hystrix.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.vertx</groupId>
+					<artifactId>vertx-unit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- OpenTracing -->


### PR DESCRIPTION
vertx-unit cause error when deploy to openshift using: mvn package fabric8:deploy. The error "The command 'run' is not a valid command" arise. Removing vertx-unit from dependency solves the issue.